### PR TITLE
Add autocomplete

### DIFF
--- a/better-code-editing.php
+++ b/better-code-editing.php
@@ -37,6 +37,9 @@ class Better_Code_Editing_Plugin {
 			'inputStyle' => 'contenteditable',
 			'lineNumbers' => true,
 			'lineWrapping' => true,
+			'extraKeys' => array(
+				'Ctrl-Space' => 'autocomplete',
+			),
 		),
 		'csslint' => array(
 			'rules' => array(
@@ -321,6 +324,7 @@ class Better_Code_Editing_Plugin {
 					break;
 				case 'text/css':
 					wp_enqueue_script( 'codemirror-mode-css' );
+					wp_enqueue_script( 'codemirror-addon-hint-css' );
 
 					if ( ! empty( $settings['codemirror']['lint'] ) ) {
 						wp_enqueue_script( 'codemirror-addon-lint-css' );

--- a/better-code-editing.php
+++ b/better-code-editing.php
@@ -225,25 +225,21 @@ class Better_Code_Editing_Plugin {
 		if ( 'text/css' === $type || in_array( $extension, array( 'sass', 'scss', 'less' ), true ) ) {
 			$settings['codemirror'] = array_merge( $settings['codemirror'], array(
 				'mode' => 'text/css',
-				'gutters' => array( 'CodeMirror-lint-markers' ),
 				'lint' => true,
 			) );
 		} elseif ( in_array( $extension, array( 'php', 'phtml', 'php3', 'php4', 'php5', 'php7', 'phps' ), true ) ) {
-			$settings['codemirror']['mode'] = 'application/x-httpd-php';
 			$settings['codemirror'] = array_merge( $settings['codemirror'], array(
-				'gutters' => array( 'CodeMirror-lint-markers' ),
+				'mode' => 'application/x-httpd-php',
 				'lint' => true,
 			) );
 		} elseif ( 'application/javascript' === $type ) {
 			$settings['codemirror'] = array_merge( $settings['codemirror'], array(
 				'mode' => 'text/javascript',
-				'gutters' => array( 'CodeMirror-lint-markers' ),
 				'lint' => true,
 			) );
 		} elseif ( 'text/html' === $type ) {
 			$settings['codemirror'] = array_merge( $settings['codemirror'], array(
 				'mode' => 'htmlmixed',
-				'gutters' => array( 'CodeMirror-lint-markers' ),
 				'lint' => true,
 			) );
 
@@ -254,6 +250,10 @@ class Better_Code_Editing_Plugin {
 			$settings['codemirror']['mode'] = 'application/xml';
 		} else {
 			$settings['codemirror']['mode'] = 'text/plain';
+		}
+
+		if ( ! empty( $settings['codemirror'] ) ) {
+			$settings['codemirror']['gutters'][] = 'CodeMirror-lint-markers';
 		}
 
 		/**

--- a/better-code-editing.php
+++ b/better-code-editing.php
@@ -126,7 +126,7 @@ class Better_Code_Editing_Plugin {
 
 		$scripts->add( 'codemirror-addon-hint-show',       plugins_url( 'wp-includes/js/codemirror/addon/hint/show-hint.js', __FILE__ ),       array( 'codemirror' ), self::CODEMIRROR_VERSION );
 		$scripts->add( 'codemirror-addon-hint-css',        plugins_url( 'wp-includes/js/codemirror/addon/hint/css-hint.js', __FILE__ ),        array( 'codemirror-addon-hint-show', 'codemirror-mode-css' ), self::CODEMIRROR_VERSION );
-		$scripts->add( 'codemirror-addon-hint-html',       plugins_url( 'wp-includes/js/codemirror/addon/hint/html-hint.js', __FILE__ ),       array( 'codemirror-addon-hint-show', 'codemirror-mode-html' ), self::CODEMIRROR_VERSION );
+		$scripts->add( 'codemirror-addon-hint-html',       plugins_url( 'wp-includes/js/codemirror/addon/hint/html-hint.js', __FILE__ ),       array( 'codemirror-addon-hint-show', 'codemirror-addon-hint-xml', 'codemirror-mode-html' ), self::CODEMIRROR_VERSION );
 		$scripts->add( 'codemirror-addon-hint-javascript', plugins_url( 'wp-includes/js/codemirror/addon/hint/javascript-hint.js', __FILE__ ), array( 'codemirror-addon-hint-show', 'codemirror-mode-javascript' ), self::CODEMIRROR_VERSION );
 		$scripts->add( 'codemirror-addon-hint-sql',        plugins_url( 'wp-includes/js/codemirror/addon/hint/sql-hint.js', __FILE__ ),        array( 'codemirror-addon-hint-show', 'codemirror-mode-sql' ), self::CODEMIRROR_VERSION );
 		$scripts->add( 'codemirror-addon-hint-xml',        plugins_url( 'wp-includes/js/codemirror/addon/hint/xml-hint.js', __FILE__ ),        array( 'codemirror-addon-hint-show', 'codemirror-mode-xml' ), self::CODEMIRROR_VERSION );
@@ -304,6 +304,7 @@ class Better_Code_Editing_Plugin {
 					break;
 				case 'htmlmixed':
 					wp_enqueue_script( 'codemirror-mode-html' );
+					wp_enqueue_script( 'codemirror-addon-hint-html' );
 
 					if ( ! empty( $settings['codemirror']['lint'] ) ) {
 						if ( ! current_user_can( 'unfiltered_html' ) ) {

--- a/better-code-editing.php
+++ b/better-code-editing.php
@@ -314,6 +314,7 @@ class Better_Code_Editing_Plugin {
 					break;
 				case 'text/javascript':
 					wp_enqueue_script( 'codemirror-mode-javascript' );
+					wp_enqueue_script( 'codemirror-addon-hint-javascript' );
 
 					if ( ! empty( $settings['codemirror']['lint'] ) ) {
 						wp_enqueue_script( 'codemirror-addon-lint-javascript' );

--- a/wp-admin/css/customize-controls-addendum.css
+++ b/wp-admin/css/customize-controls-addendum.css
@@ -1,6 +1,7 @@
 .customize-section-description-container + #customize-control-custom_css:last-child .CodeMirror {
 	height: calc( 100vh - 185px );
 }
-.CodeMirror-lint-tooltip {
+.CodeMirror-lint-tooltip,
+.CodeMirror-hints {
 	z-index: 500000 !important;
 }

--- a/wp-admin/css/widgets-addendum.css
+++ b/wp-admin/css/widgets-addendum.css
@@ -7,3 +7,6 @@
 	padding-top: 1px;
 	padding-bottom: 1px;
 }
+ul.CodeMirror-hints {
+	z-index: 101; /* Due to z-index 100 set on .widget.open */
+}

--- a/wp-admin/js/code-editor.js
+++ b/wp-admin/js/code-editor.js
@@ -106,7 +106,9 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 				}
 				shouldAutocomplete = isAlphaKey;
 				if ( ! shouldAutocomplete && 'htmlmixed' === instanceSettings.codemirror.mode ) {
-					shouldAutocomplete = '/' ===   event.key || '<' === event.key;
+					shouldAutocomplete =
+						'<' === event.key ||
+						'/' === event.key && /<\/$/.test( editor.doc.getLine( editor.doc.getCursor().line ).substr( 0, editor.doc.getCursor().ch ) );
 				} else if ( ! shouldAutocomplete && 'text/css' === instanceSettings.codemirror.mode ) {
 					shouldAutocomplete =
 						':' === event.key ||

--- a/wp-admin/js/code-editor.js
+++ b/wp-admin/js/code-editor.js
@@ -98,6 +98,14 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 		// Keep track of the instances that have been created.
 		wp.codeEditor.instances.push( editor );
 
+		if ( editor.showHint ) {
+			editor.on( 'keyup', function( _editor, event ) {
+				if ( ! editor.state.completionActive && ( event.keyCode >= 'A'.charCodeAt( 0 ) && event.keyCode <= 'z'.charCodeAt( 0 ) ) ) {
+					CodeMirror.commands.autocomplete( editor, null, { completeSingle: false } );
+				}
+			});
+		}
+
 		// Make sure the editor gets updated if the content was updated on the server (sanitization) but not updated in the editor since it was focused.
 		editor.on( 'blur', function() {
 			$textarea.data( 'next-tab-blurs', false );

--- a/wp-admin/js/code-editor.js
+++ b/wp-admin/js/code-editor.js
@@ -76,7 +76,7 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			}
 
 			// Configure HTMLHint.
-			if ( ( 'text/html' === instanceSettings.codemirror.mode || 'htmlmixed' === instanceSettings.codemirror.mode ) && true === instanceSettings.codemirror.lint && instanceSettings.htmlhint && instanceSettings.htmlhint.rules ) {
+			if ( 'htmlmixed' === instanceSettings.codemirror.mode && true === instanceSettings.codemirror.lint && instanceSettings.htmlhint && instanceSettings.htmlhint.rules ) {
 				instanceSettings.codemirror.lint = $.extend( {}, instanceSettings.htmlhint );
 
 				if ( instanceSettings.jshint && instanceSettings.jshint.rules ) {
@@ -100,7 +100,21 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 
 		if ( editor.showHint ) {
 			editor.on( 'keyup', function( _editor, event ) {
-				if ( ! editor.state.completionActive && ( event.keyCode >= 'A'.charCodeAt( 0 ) && event.keyCode <= 'z'.charCodeAt( 0 ) ) ) {
+				var shouldAutocomplete, isAlphaKey = /^[a-zA-Z]$/.test( event.key );
+				if ( editor.state.completionActive && isAlphaKey ) {
+					return;
+				}
+				shouldAutocomplete = isAlphaKey;
+				if ( ! shouldAutocomplete && 'htmlmixed' === instanceSettings.codemirror.mode ) {
+					shouldAutocomplete = '/' ===   event.key || '<' === event.key;
+				} else if ( ! shouldAutocomplete && 'text/css' === instanceSettings.codemirror.mode ) {
+					shouldAutocomplete =
+						':' === event.key ||
+						' ' === event.key && /:\s+$/.test( editor.doc.getLine( editor.doc.getCursor().line ).substr( 0, editor.doc.getCursor().ch ) );
+				} else if ( ! shouldAutocomplete && 'text/javascript' === instanceSettings.codemirror.mode ) {
+					shouldAutocomplete = '.' === event.key;
+				}
+				if ( shouldAutocomplete ) {
 					CodeMirror.commands.autocomplete( editor, null, { completeSingle: false } );
 				}
 			});


### PR DESCRIPTION
Fixes #50.

Autocomplete dialog appears when typing an alpha key (A-Za-z), or in CSS after hitting `:`, in JS when hitting `.`, and in HTML when hitting `<` or `/`.

![image](https://user-images.githubusercontent.com/134745/29747113-9e225956-8aa3-11e7-93da-86f6e1154111.png)
