### PR TITLE
Redesign warning/error messages

### DIFF
--- a/wp-admin/css/code-editor.css
+++ b/wp-admin/css/code-editor.css
@@ -1,5 +1,56 @@
 .cm-trailingspace {
-	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QUXCToH00Y1UgAAACFJREFUCNdjPMDBUc/AwNDAAAFMTAwMDA0OP34wQgX/AQBYgwYEx4f9lQAAAABJRU5ErkJggg==);
-	background-position: bottom left;
-	background-repeat: repeat-x;
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QUXCToH00Y1UgAAACFJREFUCNdjPMDBUc/AwNDAAAFMTAwMDA0OP34wQgX/AQBYgwYEx4f9lQAAAABJRU5ErkJggg==) repeat-x bottom left;
+}
+
+.wrap [class*="CodeMirror-lint-marker"],
+.wp-admin [class*="CodeMirror-lint-message"],
+.wrap .CodeMirror-lint-marker-multiple {
+	background-image: none;
+}
+
+.wrap [class*="CodeMirror-lint-marker"]:before {
+	font: normal 18px/1 dashicons;
+	position: relative;
+	top: -2px;
+}
+
+.wp-admin [class*="CodeMirror-lint-message"]:before {
+	font: normal 16px/1 dashicons;
+	left: 16px;
+	position: absolute;
+}
+
+.wp-admin .CodeMirror-lint-message-error,
+.wp-admin .CodeMirror-lint-message-warning {
+	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
+	margin: 5px 0 2px;
+	padding: 3px 12px 3px 28px;
+}
+
+.wp-admin .CodeMirror-lint-message-warning {
+	background-color: #fff8e5;
+	border-left: 4px solid #ffb900;
+}
+
+.wrap .CodeMirror-lint-marker-warning:before,
+.wp-admin .CodeMirror-lint-message-warning:before {
+	content: "\f534";
+	color: #f6a306;
+}
+
+.wp-admin .CodeMirror-lint-message-error {
+	background-color: #fbeaea;
+	border-left: 4px solid #dc3232;
+}
+
+.wrap .CodeMirror-lint-marker-error:before,
+.wp-admin .CodeMirror-lint-message-error:before {
+	content: "\f153";
+	color: #dc3232;
+}
+
+.wp-admin .CodeMirror-lint-tooltip {
+	background: none;
+	border: none;
+	border-radius: 0;
 }


### PR DESCRIPTION
Uses WP Admin color and icon scheme for warnings and errors.

Fixes #44, fixes #45.

After:
<img width="468" alt="screen shot 2017-08-28 at 12 35 54 pm" src="https://user-images.githubusercontent.com/1398304/29770172-fa650a42-8bed-11e7-9a1d-a52212dc8939.png"> 
Two messages stacked.

<img width="641" alt="screen shot 2017-08-28 at 12 37 19 pm" src="https://user-images.githubusercontent.com/1398304/29770173-fa6537ec-8bed-11e7-8d3c-297663648c68.png">
