### PR TITLE
Align matchbracket with matchtag

### DIFF
--- a/wp-admin/css/code-editor.css
+++ b/wp-admin/css/code-editor.css
@@ -3,3 +3,8 @@
 	background-position: bottom left;
 	background-repeat: repeat-x;
 }
+
+.wrap .CodeMirror .CodeMirror-matchingbracket {
+	background: rgba(255, 150, 0, .3);
+	color: inherit;
+}


### PR DESCRIPTION
Gives matching brackets and matching tags the same visual highlight.

Fixes #56.

After:

<img width="220" alt="screen shot 2017-08-28 at 12 55 25 pm" src="https://user-images.githubusercontent.com/1398304/29770636-40a13524-8bf0-11e7-947e-aad67b420ab7.png">
