### PR TITLE
Prevent saving when lint errors present

### DIFF
--- a/wp-admin/css/code-editor.css
+++ b/wp-admin/css/code-editor.css
@@ -3,7 +3,7 @@
 }
 
 .wrap [class*="CodeMirror-lint-marker"],
-.wp-admin [class*="CodeMirror-lint-message"],
+.wp-core-ui [class*="CodeMirror-lint-message"],
 .wrap .CodeMirror-lint-marker-multiple {
 	background-image: none;
 }
@@ -14,42 +14,42 @@
 	top: -2px;
 }
 
-.wp-admin [class*="CodeMirror-lint-message"]:before {
+.wp-core-ui [class*="CodeMirror-lint-message"]:before {
 	font: normal 16px/1 dashicons;
 	left: 16px;
 	position: absolute;
 }
 
-.wp-admin .CodeMirror-lint-message-error,
-.wp-admin .CodeMirror-lint-message-warning {
+.wp-core-ui .CodeMirror-lint-message-error,
+.wp-core-ui .CodeMirror-lint-message-warning {
 	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
 	margin: 5px 0 2px;
 	padding: 3px 12px 3px 28px;
 }
 
-.wp-admin .CodeMirror-lint-message-warning {
+.wp-core-ui .CodeMirror-lint-message-warning {
 	background-color: #fff8e5;
 	border-left: 4px solid #ffb900;
 }
 
 .wrap .CodeMirror-lint-marker-warning:before,
-.wp-admin .CodeMirror-lint-message-warning:before {
+.wp-core-ui .CodeMirror-lint-message-warning:before {
 	content: "\f534";
 	color: #f6a306;
 }
 
-.wp-admin .CodeMirror-lint-message-error {
+.wp-core-ui .CodeMirror-lint-message-error {
 	background-color: #fbeaea;
 	border-left: 4px solid #dc3232;
 }
 
 .wrap .CodeMirror-lint-marker-error:before,
-.wp-admin .CodeMirror-lint-message-error:before {
+.wp-core-ui .CodeMirror-lint-message-error:before {
 	content: "\f153";
 	color: #dc3232;
 }
 
-.wp-admin .CodeMirror-lint-tooltip {
+.wp-core-ui .CodeMirror-lint-tooltip {
 	background: none;
 	border: none;
 	border-radius: 0;

--- a/wp-admin/css/common.css
+++ b/wp-admin/css/common.css
@@ -3105,6 +3105,25 @@ img {
 	width: 97%;
 }
 
+#file-editor-linting-error {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+#file-editor-linting-error > .notice {
+	margin: 0;
+	display: inline-block;
+}
+#file-editor-linting-error > .notice > p {
+	width: auto;
+}
+#template .submit {
+	margin-top: 1em;
+	padding: 0;
+}
+
+#template .submit input[type=submit][disabled] {
+	cursor: not-allowed;
+}
 #templateside {
 	float: right;
 	width: 190px;

--- a/wp-admin/css/customize-controls-addendum.css
+++ b/wp-admin/css/customize-controls-addendum.css
@@ -12,3 +12,8 @@
 .customize-section-description ul > li {
 	list-style: disc;
 }
+
+.customize-section-description-container + #customize-control-custom_css:last-child .customize-control-notifications-container {
+	margin-left: 12px;
+	margin-right: 12px;
+}

--- a/wp-admin/css/widgets-addendum.css
+++ b/wp-admin/css/widgets-addendum.css
@@ -10,3 +10,6 @@
 ul.CodeMirror-hints {
 	z-index: 101; /* Due to z-index 100 set on .widget.open */
 }
+.widget-control-actions .custom-html-widget-save-button.button[disabled] {
+	cursor: not-allowed;
+}

--- a/wp-admin/file-editor-addendum.php
+++ b/wp-admin/file-editor-addendum.php
@@ -109,7 +109,7 @@ function _better_code_editing_admin_enqueue_scripts_for_file_editor( $hook ) {
 	?>
 	<script>
 		jQuery( function( $ ) {
-			var settings = {}, noticeContainer, errorNotice, l10n, updateNotice, currentErrorAnnotations = [], editor;
+			var settings = {}, noticeContainer, errorNotice, l10n, updateNotice, currentErrorAnnotations = [], editor, previousErrorCount;
 			settings = <?php echo wp_json_encode( $settings ); ?>;
 			l10n = <?php echo wp_json_encode( $l10n ); ?>;
 			settings.handleTabPrev = function() {
@@ -149,12 +149,13 @@ function _better_code_editing_admin_enqueue_scripts_for_file_editor( $hook ) {
 					/*
 					 * Update notifications when the editor is not focused to prevent error message
 					 * from overwhelming the user during input, unless there are no annotations
-					 * and in that case update immediately so they can know that they fixed the
-					 * errors.
+					 * or there are previous notifications already being displayed, and in that
+					 * case update immediately so they can know that they fixed the errors.
 					 */
-					if ( ! editor.state.focused || 0 === currentErrorAnnotations.length ) {
+					if ( ! editor.state.focused || 0 === currentErrorAnnotations.length || previousErrorCount > 0 && currentErrorAnnotations.length !== previousErrorCount ) {
 						updateNotice();
 					}
+					previousErrorCount = currentErrorAnnotations.length;
 				};
 			}
 			editor = wp.codeEditor.initialize( $( '#newcontent' ), settings );

--- a/wp-admin/js/code-editor.js
+++ b/wp-admin/js/code-editor.js
@@ -68,22 +68,31 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 		instanceSettings = $.extend( {}, wp.codeEditor.defaultSettings, settings );
 		instanceSettings.codemirror = $.extend( {}, instanceSettings.codemirror );
 
-		if ( true === instanceSettings.codemirror.lint ) {
+		// @todo This can be moved to PHP.
+		if ( instanceSettings.codemirror.lint ) {
+			if ( true === instanceSettings.codemirror.lint ) {
+				instanceSettings.codemirror.lint = {};
+			}
+
+			// Note that rules must be sent in the "deprecated" lint.options property to prevent linter from complaining about unrecognized options.
+			if ( ! instanceSettings.codemirror.lint.options ) {
+				instanceSettings.codemirror.lint.options = {};
+			}
 
 			// Configure JSHint.
-			if ( 'text/javascript' === instanceSettings.codemirror.mode && true === instanceSettings.codemirror.lint && instanceSettings.jshint && instanceSettings.jshint.rules ) {
-				instanceSettings.codemirror.lint = instanceSettings.jshint.rules;
+			if ( 'javascript' === instanceSettings.codemirror.mode && instanceSettings.jshint && instanceSettings.jshint.rules ) {
+				instanceSettings.codemirror.lint.options = $.extend( {}, instanceSettings.jshint.rules, instanceSettings.codemirror.lint.options );
 			}
 
 			// Configure HTMLHint.
-			if ( 'htmlmixed' === instanceSettings.codemirror.mode && true === instanceSettings.codemirror.lint && instanceSettings.htmlhint && instanceSettings.htmlhint.rules ) {
-				instanceSettings.codemirror.lint = $.extend( {}, instanceSettings.htmlhint );
+			if ( 'htmlmixed' === instanceSettings.codemirror.mode && instanceSettings.htmlhint && instanceSettings.htmlhint.rules ) {
+				instanceSettings.codemirror.lint.options = $.extend( {}, instanceSettings.htmlhint, instanceSettings.codemirror.lint.options );
 
 				if ( instanceSettings.jshint && instanceSettings.jshint.rules ) {
-					instanceSettings.codemirror.lint.rules.jshint = instanceSettings.jshint.rules;
+					instanceSettings.codemirror.lint.options.rules.jshint = $.extend( {}, instanceSettings.jshint.rules, instanceSettings.codemirror.lint.options.rules.jshint );
 				}
 				if ( instanceSettings.csslint && instanceSettings.csslint.rules ) {
-					instanceSettings.codemirror.lint.rules.csslint = instanceSettings.csslint.rules;
+					instanceSettings.codemirror.lint.options.rules.csslint = $.extend( {}, instanceSettings.csslint.rules, instanceSettings.codemirror.lint.options.rules.csslint );
 				}
 			}
 

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -74,13 +74,13 @@
 					if ( 1 === currentErrorAnnotations.length ) {
 						control.setting.notifications.remove( 'csslint_errors' );
 						control.setting.notifications.add( 'csslint_error', new api.Notification( 'csslint_error', {
-							message: 'There is 1 error in the CSS that must be fixed.', // @todo l10n
+							message: api.l10n.customCssErrorNotice.singular.replace( '%d', '1' ),
 							type: 'error'
 						} ) );
 					} else if ( currentErrorAnnotations.length > 1 ) {
 						control.setting.notifications.remove( 'csslint_error' );
 						control.setting.notifications.add( 'csslint_errors', new api.Notification( 'csslint_errors', {
-							message: 'There is ' + String( currentErrorAnnotations.length ) + ' error in the CSS that must be fixed.', // @todo l10n
+							message: api.l10n.customCssErrorNotice.plural.replace( '%d', String( currentErrorAnnotations.length ) ),
 							type: 'error'
 						} ) );
 					} else {

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -22,6 +22,23 @@
 				};
 			})( control.setting.notifications.add );
 
+			// Make sure editor gets focused when control is focused.
+			control.focus = (function( originalFocus ) { // eslint-disable-line max-nested-callbacks
+				return function( params ) { // eslint-disable-line max-nested-callbacks
+					var extendedParams = _.extend( {}, params ), originalCompleteCallback;
+					originalCompleteCallback = extendedParams.completeCallback;
+					extendedParams.completeCallback = function() {
+						if ( originalCompleteCallback ) {
+							originalCompleteCallback();
+						}
+						if ( control.editor ) {
+							control.editor.focus();
+						}
+					};
+					originalFocus.call( this, extendedParams );
+				};
+			})( control.focus );
+
 			onceExpanded = function() {
 				var $textarea = control.container.find( 'textarea' ), settings, currentAnnotations = [];
 

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -71,21 +71,26 @@
 				 * @returns {void}
 				 */
 				function updateNotifications() {
-					if ( 1 === currentErrorAnnotations.length ) {
-						control.setting.notifications.remove( 'csslint_errors' );
+					var message;
+
+					// Short-circuit if there are no changes to the error.
+					if ( previousErrorCount === currentErrorAnnotations.length ) {
+						return;
+					}
+					previousErrorCount = currentErrorAnnotations.length;
+
+					control.setting.notifications.remove( 'csslint_error' );
+
+					if ( 0 !== currentErrorAnnotations.length ) {
+						if ( 1 === currentErrorAnnotations.length ) {
+							message = api.l10n.customCssErrorNotice.singular.replace( '%d', '1' );
+						} else {
+							message = api.l10n.customCssErrorNotice.plural.replace( '%d', String( currentErrorAnnotations.length ) );
+						}
 						control.setting.notifications.add( 'csslint_error', new api.Notification( 'csslint_error', {
-							message: api.l10n.customCssErrorNotice.singular.replace( '%d', '1' ),
+							message: message,
 							type: 'error'
 						} ) );
-					} else if ( currentErrorAnnotations.length > 1 ) {
-						control.setting.notifications.remove( 'csslint_error' );
-						control.setting.notifications.add( 'csslint_errors', new api.Notification( 'csslint_errors', {
-							message: api.l10n.customCssErrorNotice.plural.replace( '%d', String( currentErrorAnnotations.length ) ),
-							type: 'error'
-						} ) );
-					} else {
-						control.setting.notifications.remove( 'csslint_error' );
-						control.setting.notifications.remove( 'csslint_errors' );
 					}
 				}
 
@@ -105,10 +110,9 @@
 							 * or there are previous notifications already being displayed, and in that
 							 * case update immediately so they can know that they fixed the errors.
 							 */
-							if ( ! editor.state.focused || 0 === currentErrorAnnotations.length || previousErrorCount > 0 && currentErrorAnnotations.length !== previousErrorCount ) {
+							if ( ! editor.state.focused || 0 === currentErrorAnnotations.length || previousErrorCount > 0 ) {
 								updateNotifications();
 							}
-							previousErrorCount = currentErrorAnnotations.length;
 						}
 					} );
 				}

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -40,7 +40,7 @@
 			})( control.focus );
 
 			onceExpanded = function() {
-				var $textarea = control.container.find( 'textarea' ), settings, currentErrorAnnotations = [];
+				var $textarea = control.container.find( 'textarea' ), settings, previousErrorCount = 0, currentErrorAnnotations = [];
 
 				settings = _.extend( {}, api.settings.codeEditor, {
 					handleTabNext: function() {
@@ -102,12 +102,13 @@
 							/*
 							 * Update notifications when the editor is not focused to prevent error message
 							 * from overwhelming the user during input, unless there are no annotations
-							 * and in that case update immediately so they can know that they fixed the
-							 * errors.
+							 * or there are previous notifications already being displayed, and in that
+							 * case update immediately so they can know that they fixed the errors.
 							 */
-							if ( ! editor.state.focused || 0 === currentErrorAnnotations.length ) {
+							if ( ! editor.state.focused || 0 === currentErrorAnnotations.length || previousErrorCount > 0 && currentErrorAnnotations.length !== previousErrorCount ) {
 								updateNotifications();
 							}
+							previousErrorCount = currentErrorAnnotations.length;
 						}
 					} );
 				}

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -11,17 +11,16 @@
 				return;
 			}
 
-			// Workaround for disabling server-sent syntax checking notifications.
-			// @todo Listen for errors in CodeMirror and opt-to add invalidity notifications for them? The presence of such notification error allows saving to be blocked.
+			// Workaround for disabling server-sent syntax checking notifications. This can be removed from core in the merge.
 			control.setting.notifications.add = (function( originalAdd ) { // eslint-disable-line max-nested-callbacks
 				return function( id, notification ) { // eslint-disable-line max-nested-callbacks
 					if ( 'imbalanced_curly_brackets' === id && notification.fromServer ) {
 						return null;
 					} else {
-						return originalAdd( id, notification );
+						return originalAdd.call( this, id, notification );
 					}
 				};
-			})( control.setting.notifications );
+			})( control.setting.notifications.add );
 
 			onceExpanded = function() {
 				var $textarea = control.container.find( 'textarea' );

--- a/wp-admin/js/theme-plugin-editor.js
+++ b/wp-admin/js/theme-plugin-editor.js
@@ -1,0 +1,108 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [-1, 0, 1] }] */
+
+if ( ! window.wp ) {
+	window.wp = {};
+}
+
+wp.themePluginEditor = (function( $ ) {
+	'use strict';
+
+	var component = {
+		l10n: {
+			lintError: {
+				singular: '',
+				plural: ''
+			}
+		},
+		instance: null
+	};
+
+	/**
+	 * Initialize component.
+	 *
+	 * @param {object} settings Settings.
+	 * @returns {void}
+	 */
+	component.init = function( settings ) {
+		var codeEditorSettings, noticeContainer, errorNotice, updateNotice, currentErrorAnnotations = [], editor, previousErrorCount = 0;
+
+		codeEditorSettings = $.extend( {}, settings );
+
+		codeEditorSettings.handleTabPrev = function() {
+			$( '#templateside' ).find( ':tabbable' ).last().focus();
+		};
+		codeEditorSettings.handleTabNext = function() {
+			$( '#template' ).find( ':tabbable:not(.CodeMirror-code)' ).first().focus();
+		};
+
+		updateNotice = function() {
+			var message;
+
+			// Short-circuit if there is no update for the message.
+			if ( currentErrorAnnotations.length === previousErrorCount ) {
+				return;
+			}
+
+			previousErrorCount = currentErrorAnnotations.length;
+
+			$( '#submit' ).prop( 'disabled', 0 !== currentErrorAnnotations.length );
+			if ( 0 !== currentErrorAnnotations.length ) {
+				errorNotice.empty();
+				if ( 1 === currentErrorAnnotations.length ) {
+					message = component.l10n.singular.replace( '%d', '1' );
+				} else {
+					message = component.l10n.plural.replace( '%d', String( currentErrorAnnotations.length ) );
+				}
+				errorNotice.append( $( '<p></p>', {
+					text: message
+				} ) );
+				noticeContainer.slideDown( 'fast' );
+				wp.a11y.speak( message );
+			} else {
+				noticeContainer.slideUp( 'fast' );
+			}
+		};
+
+		if ( codeEditorSettings.codemirror.lint ) {
+			if ( true === codeEditorSettings.codemirror.lint ) {
+				codeEditorSettings.codemirror.lint = {};
+			}
+			noticeContainer = $( '<div id="file-editor-linting-error"></div>' );
+			errorNotice = $( '<div class="inline notice notice-error"></div>' );
+			noticeContainer.append( errorNotice );
+			noticeContainer.hide();
+			$( 'p.submit' ).before( noticeContainer );
+			codeEditorSettings.codemirror.lint = _.extend( {}, codeEditorSettings.codemirror.lint, {
+				onUpdateLinting: function( annotations, annotationsSorted, cm ) {
+					currentErrorAnnotations = _.filter( annotations, function( annotation ) {
+						return 'error' === annotation.severity;
+					} );
+
+					/*
+					 * Update notifications when the editor is not focused to prevent error message
+					 * from overwhelming the user during input, unless there are no annotations
+					 * or there are previous notifications already being displayed, and in that
+					 * case update immediately so they can know that they fixed the errors.
+					 */
+					if ( ! cm.state.focused || 0 === currentErrorAnnotations.length || previousErrorCount > 0 ) {
+						updateNotice();
+					}
+				}
+			} );
+		}
+		editor = wp.codeEditor.initialize( $( '#newcontent' ), codeEditorSettings );
+
+		if ( codeEditorSettings.codemirror.lint ) {
+			editor.on( 'blur', function() {
+				updateNotice();
+			});
+			$( editor.display.wrapper ).on( 'mouseout', function() {
+				updateNotice();
+			});
+		}
+
+		component.instance = editor;
+	};
+
+	return component;
+})( jQuery );

--- a/wp-includes/customize-manager-addendum.php
+++ b/wp-includes/customize-manager-addendum.php
@@ -81,7 +81,12 @@ function _better_code_editing_customize_controls_enqueue_scripts() {
  */
 function _better_code_editing_amend_customize_pane_settings() {
 	global $wp_customize;
-	if ( ! empty( $wp_customize->custom_css_code_editor_settings ) ) {
-		printf( '<script>window._wpCustomizeSettings.codeEditor = %s</script>;', wp_json_encode( $wp_customize->custom_css_code_editor_settings ) );
+	if ( empty( $wp_customize->custom_css_code_editor_settings ) ) {
+		return;
 	}
+	printf( '<script>window._wpCustomizeSettings.codeEditor = %s</script>;', wp_json_encode( $wp_customize->custom_css_code_editor_settings ) );
+
+	/* translators: placeholder is error count */
+	$l10n = _n_noop( 'There is %d error which must be fixed before you can save.', 'There are %d errors which must be fixed before you can save.', 'better-code-editing' );
+	printf( '<script>window._wpCustomizeControlsL10n.customCssErrorNotice = %s</script>;', wp_json_encode( wp_array_slice_assoc( $l10n, array( 'singular', 'plural' ) ) ) );
 }

--- a/wp-includes/script-loader-addendum.php
+++ b/wp-includes/script-loader-addendum.php
@@ -120,7 +120,7 @@ function _better_code_editing_default_scripts( WP_Scripts $scripts ) {
 
 	$scripts->add( 'code-editor', plugins_url( 'wp-admin/js/code-editor.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'jquery', 'codemirror' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
 
-	$scripts->add( 'custom-html-widgets', plugins_url( 'wp-admin/js/widgets/custom-html-widgets.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'code-editor', 'jquery', 'backbone', 'wp-util' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
+	$scripts->add( 'custom-html-widgets', plugins_url( 'wp-admin/js/widgets/custom-html-widgets.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'code-editor', 'jquery', 'backbone', 'wp-util', 'jquery-ui-core', 'wp-a11y' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
 
 	if ( defined( 'SCRIPT_DEBUG' ) ) {
 		_better_code_editing_report_asset_errors( $scripts );

--- a/wp-includes/script-loader-addendum.php
+++ b/wp-includes/script-loader-addendum.php
@@ -121,6 +121,7 @@ function _better_code_editing_default_scripts( WP_Scripts $scripts ) {
 	$scripts->add( 'code-editor', plugins_url( 'wp-admin/js/code-editor.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'jquery', 'codemirror' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
 
 	$scripts->add( 'custom-html-widgets', plugins_url( 'wp-admin/js/widgets/custom-html-widgets.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'code-editor', 'jquery', 'backbone', 'wp-util', 'jquery-ui-core', 'wp-a11y' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
+	$scripts->add( 'wp-theme-plugin-editor', plugins_url( 'wp-admin/js/theme-plugin-editor.js', BETTER_CODE_EDITING_PLUGIN_FILE ), array( 'code-editor', 'jquery', 'jquery-ui-core', 'wp-a11y', 'underscore' ), BETTER_CODE_EDITING_PLUGIN_VERSION );
 
 	if ( defined( 'SCRIPT_DEBUG' ) ) {
 		_better_code_editing_report_asset_errors( $scripts );

--- a/wp-includes/widgets/class-wp-widget-custom-html-codemirror.php
+++ b/wp-includes/widgets/class-wp-widget-custom-html-codemirror.php
@@ -68,6 +68,15 @@ class WP_Widget_Custom_HTML_CodeMirror extends WP_Widget_Custom_HTML {
 			wp_enqueue_code_editor( $settings );
 		}
 		wp_add_inline_script( 'custom-html-widgets', sprintf( 'wp.customHtmlWidgets.init( %s );', wp_json_encode( $settings ) ), 'after' );
+
+		$l10n = array(
+			'errorNotice' => wp_array_slice_assoc(
+				/* translators: placeholder is error count */
+				_n_noop( 'There is %d error which must be fixed before you can save.', 'There are %d errors which must be fixed before you can save.', 'better-code-editing' ),
+				array( 'singular', 'plural' )
+			),
+		);
+		wp_add_inline_script( 'custom-html-widgets', sprintf( 'jQuery.extend( wp.customHtmlWidgets.l10n, %s );', wp_json_encode( $l10n ) ), 'after' );
 	}
 
 	/**
@@ -120,6 +129,8 @@ class WP_Widget_Custom_HTML_CodeMirror extends WP_Widget_Custom_HTML {
 					<# } #>
 				<?php endif; ?>
 			<?php endif; ?>
+
+			<div class="code-editor-error-container"></div>
 		</script>
 		<?php
 	}


### PR DESCRIPTION
Fixes #49.

By integrating with the lint addon in CodeMirror, the file editor in WordPress can block saving when an error is detected. When applied to PHP, this can help prevent against whitescreening your site. CodeMirror's syntax highlighting and autocompletion of braces also guards against syntax errors while coding.

Demo video on YouTube:

[![Play video on YouTube](https://i1.ytimg.com/vi/lwkr-CddXqw/maxresdefault.jpg)](https://www.youtube.com/watch?v=lwkr-CddXqw)

