### PR TITLE
Auto-show Custom CSS section description when value is empty; add close link to bottom (cf. Trac #39892)

### DIFF
--- a/wp-admin/css/customize-controls-addendum.css
+++ b/wp-admin/css/customize-controls-addendum.css
@@ -17,3 +17,12 @@
 	margin-left: 12px;
 	margin-right: 12px;
 }
+
+.section-description-buttons {
+	text-align: right;
+}
+
+.section-description-buttons button.button-link {
+	color: #0073aa; /* @todo Color scheme? */
+	text-decoration: underline;
+}

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -54,7 +54,7 @@
 			onceExpanded = function() {
 				var $textarea = control.container.find( 'textarea' ), settings, previousErrorCount = 0, currentErrorAnnotations = [];
 
-				if ( api.settings.customCss.isDefault ) {
+				if ( ! control.setting.get() ) {
 					section.container.find( '.section-meta .customize-section-description:first' )
 						.addClass( 'open' )
 						.show()

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -3,11 +3,23 @@
 	'use strict';
 
 	api.section( 'custom_css', function( section ) {
+		if ( ! api.settings.customCss ) {
+			return;
+		}
+
+		// Close the section description when clicking the close button.
+		section.container.find( '.section-description-buttons .section-description-close' ).on( 'click', function() {
+			section.container.find( '.section-meta .customize-section-description:first' )
+				.removeClass( 'open' )
+				.slideUp()
+				.attr( 'aria-expanded', 'false' );
+		});
+
 		api.control( 'custom_css', function( control ) {
 			var onceExpanded, onExpandedChange;
 
 			// Abort if CodeMirror disabled via customizer_custom_css_codemirror_opts filter.
-			if ( ! api.settings.codeEditor ) {
+			if ( ! api.settings.customCss.codeEditor ) {
 				return;
 			}
 
@@ -42,7 +54,14 @@
 			onceExpanded = function() {
 				var $textarea = control.container.find( 'textarea' ), settings, previousErrorCount = 0, currentErrorAnnotations = [];
 
-				settings = _.extend( {}, api.settings.codeEditor, {
+				if ( api.settings.customCss.isDefault ) {
+					section.container.find( '.section-meta .customize-section-description:first' )
+						.addClass( 'open' )
+						.show()
+						.attr( 'aria-expanded', 'true' );
+				}
+
+				settings = _.extend( {}, api.settings.customCss.codeEditor, {
 					handleTabNext: function() {
 						var controls, controlIndex;
 						controls = section.controls();

--- a/wp-includes/customize-manager-addendum.php
+++ b/wp-includes/customize-manager-addendum.php
@@ -24,6 +24,13 @@ function _better_code_editing_amend_custom_css_help_text( WP_Customize_Manager $
 		return;
 	}
 
+	// Remove default value from Custom CSS setting.
+	foreach ( $wp_customize->settings() as $setting ) {
+		if ( $setting instanceof WP_Customize_Custom_CSS_Setting ) {
+			$setting->default = '';
+		}
+	}
+
 	$section->description = '<p>';
 	$section->description .= __( 'Add your own CSS code here to customize the appearance and layout of your site.', 'better-code-editing' );
 	$section->description .= sprintf(
@@ -91,7 +98,6 @@ function _better_code_editing_amend_customize_pane_settings() {
 
 	$settings = array(
 		'codeEditor' => $wp_customize->custom_css_code_editor_settings,
-		'isDefault' => $custom_css_setting->value() === $custom_css_setting->default,
 	);
 
 	printf( '<script>window._wpCustomizeSettings.customCss = %s</script>;', wp_json_encode( $settings ) );

--- a/wp-includes/customize-manager-addendum.php
+++ b/wp-includes/customize-manager-addendum.php
@@ -54,6 +54,10 @@ function _better_code_editing_amend_custom_css_help_text( WP_Customize_Manager $
 		)
 	);
 	$section->description .= '</p>';
+
+	$section->description .= '<p class="section-description-buttons">';
+	$section->description .= '<button type="button" class="button-link section-description-close">' . __( 'Close', 'default' ) . '</button>';
+	$section->description .= '</p>';
 }
 
 /**
@@ -80,7 +84,17 @@ function _better_code_editing_amend_customize_pane_settings() {
 	if ( empty( $wp_customize->custom_css_code_editor_settings ) ) {
 		return;
 	}
-	printf( '<script>window._wpCustomizeSettings.codeEditor = %s</script>;', wp_json_encode( $wp_customize->custom_css_code_editor_settings ) );
+	$custom_css_setting = $wp_customize->get_setting( sprintf( 'custom_css[%s]', get_stylesheet() ) );
+	if ( ! $custom_css_setting ) {
+		return;
+	}
+
+	$settings = array(
+		'codeEditor' => $wp_customize->custom_css_code_editor_settings,
+		'isDefault' => $custom_css_setting->value() === $custom_css_setting->default,
+	);
+
+	printf( '<script>window._wpCustomizeSettings.customCss = %s</script>;', wp_json_encode( $settings ) );
 
 	/* translators: placeholder is error count */
 	$l10n = _n_noop( 'There is %d error which must be fixed before you can save.', 'There are %d errors which must be fixed before you can save.', 'better-code-editing' );


### PR DESCRIPTION
Fixes #79.

- [x] Should we get rid of the placeholder CSS comment value now if this help text is shown?

![image](https://user-images.githubusercontent.com/134745/30097529-ee471f56-9292-11e7-858a-e85a74318ec2.png)

See https://core.trac.wordpress.org/ticket/39892