### PR TITLE
Improve frequency for when linting error notifications are shown

### DIFF
--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -44,7 +44,7 @@
 							originalCompleteCallback();
 						}
 						if ( control.editor ) {
-							control.editor.focus();
+							control.editor.codemirror.focus();
 						}
 					};
 					originalFocus.call( this, extendedParams );
@@ -68,7 +68,7 @@
 					 *
 					 * @returns {void}
 					 */
-					handleTabNext: function handleTabNext() {
+					onTabNext: function onTabNext() {
 						var controls, controlIndex;
 						controls = section.controls();
 						controlIndex = controls.indexOf( control );
@@ -84,7 +84,7 @@
 					 *
 					 * @returns {void}
 					 */
-					handleTabPrev: function handleTabPrev() {
+					onTabPrevious: function onTabPrevious() {
 						var controls, controlIndex;
 						controls = section.controls();
 						controlIndex = controls.indexOf( control );
@@ -122,19 +122,19 @@
 				control.editor = wp.codeEditor.initialize( $textarea, settings );
 
 				// Refresh when receiving focus.
-				control.editor.on( 'focus', function( editor ) {
-					editor.refresh();
+				control.editor.codemirror.on( 'focus', function( codemirror ) {
+					codemirror.refresh();
 				});
 
 				/*
 				 * When the CodeMirror instance changes, mirror to the textarea,
 				 * where we have our "true" change event handler bound.
 				 */
-				control.editor.on( 'change', function( editor ) {
-					$textarea.val( editor.getValue() ).trigger( 'change' );
+				control.editor.codemirror.on( 'change', function( codemirror ) {
+					$textarea.val( codemirror.getValue() ).trigger( 'change' );
 				});
 
-				control.editor.on( 'keydown', function onKeydown( editor, event ) {
+				control.editor.codemirror.on( 'keydown', function onKeydown( codemirror, event ) {
 					var escKeyCode = 27;
 					if ( escKeyCode === event.keyCode ) {
 						event.stopPropagation(); // Prevent collapsing the section.

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -147,7 +147,7 @@
 				control.editor.on( 'blur', function() {
 					updateNotifications();
 				});
-				$( control.editor.display.wrapper ).on( 'mouseout', function() {
+				$( control.editor.display.wrapper ).on( 'mouseleave', function() {
 					updateNotifications();
 				});
 

--- a/wp-admin/js/customize-controls-addendum.js
+++ b/wp-admin/js/customize-controls-addendum.js
@@ -139,7 +139,7 @@
 					if ( escKeyCode === event.keyCode ) {
 						event.stopPropagation(); // Prevent collapsing the section.
 					}
-				} );
+				});
 
 				// @todo: bind something to setting change, so that we can catch other plugins modifying the css and update CodeMirror?
 			};

--- a/wp-admin/js/theme-plugin-editor.js
+++ b/wp-admin/js/theme-plugin-editor.js
@@ -96,7 +96,7 @@ wp.themePluginEditor = (function( $ ) {
 			editor.on( 'blur', function() {
 				updateNotice();
 			});
-			$( editor.display.wrapper ).on( 'mouseout', function() {
+			$( editor.display.wrapper ).on( 'mouseleave', function() {
 				updateNotice();
 			});
 		}

--- a/wp-admin/js/theme-plugin-editor.js
+++ b/wp-admin/js/theme-plugin-editor.js
@@ -33,7 +33,7 @@ wp.themePluginEditor = (function( $ ) {
 		 *
 		 * @returns {void}
 		 */
-		codeEditorSettings.handleTabPrev = function() {
+		codeEditorSettings.onTabPrevious = function() {
 			$( '#templateside' ).find( ':tabbable' ).last().focus();
 		};
 
@@ -42,7 +42,7 @@ wp.themePluginEditor = (function( $ ) {
 		 *
 		 * @returns {void}
 		 */
-		codeEditorSettings.handleTabNext = function() {
+		codeEditorSettings.onTabNext = function() {
 			$( '#template' ).find( ':tabbable:not(.CodeMirror-code)' ).first().focus();
 		};
 

--- a/wp-admin/js/widgets/custom-html-widgets.js
+++ b/wp-admin/js/widgets/custom-html-widgets.js
@@ -224,6 +224,16 @@ wp.customHtmlWidgets = ( function( $ ) {
 					control.syncContainer.find( '.sync-input.content' ).trigger( 'change' );
 				}
 			});
+
+			// Prevent hitting Esc from collapsing the widget control.
+			if ( wp.customize ) {
+				control.editor.codemirror.on( 'keydown', function onKeydown( codemirror, event ) {
+					var escKeyCode = 27;
+					if ( escKeyCode === event.keyCode ) {
+						event.stopPropagation();
+					}
+				});
+			}
 		}
 	});
 

--- a/wp-admin/js/widgets/custom-html-widgets.js
+++ b/wp-admin/js/widgets/custom-html-widgets.js
@@ -105,7 +105,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 			 * to prevent the editor's contents from getting sanitized as soon as a user removes focus from
 			 * the editor. This is particularly important for users who cannot unfiltered_html.
 			 */
-			control.contentUpdateBypassed = control.fields.content.is( document.activeElement ) || control.editor && control.editor.state.focused || 0 !== control.currentErrorAnnotations;
+			control.contentUpdateBypassed = control.fields.content.is( document.activeElement ) || control.editor && control.editor.codemirror.state.focused || 0 !== control.currentErrorAnnotations;
 			if ( ! control.contentUpdateBypassed ) {
 				syncInput = control.syncContainer.find( '.sync-input.content' );
 				control.fields.content.val( syncInput.val() ).trigger( 'change' );
@@ -169,7 +169,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 				 *
 				 * @returns {void}
 				 */
-				handleTabPrev: function handleTabPrev() {
+				onTabPrevious: function onTabPrevious() {
 					control.fields.title.focus();
 				},
 
@@ -178,7 +178,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 				 *
 				 * @returns {void}
 				 */
-				handleTabNext: function handleTabNext() {
+				onTabNext: function onTabNext() {
 					var tabbables = control.syncContainer.add( control.syncContainer.parent().find( '.widget-position, .widget-control-actions' ) ).find( ':tabbable' );
 					tabbables.first().focus();
 				},
@@ -207,19 +207,19 @@ wp.customHtmlWidgets = ( function( $ ) {
 
 			control.editor = wp.codeEditor.initialize( control.fields.content, settings );
 			control.fields.content.on( 'change', function() {
-				if ( this.value !== control.editor.getValue() ) {
-					control.editor.setValue( this.value );
+				if ( this.value !== control.editor.codemirror.getValue() ) {
+					control.editor.codemirror.setValue( this.value );
 				}
 			});
-			control.editor.on( 'change', function() {
-				var value = control.editor.getValue();
+			control.editor.codemirror.on( 'change', function() {
+				var value = control.editor.codemirror.getValue();
 				if ( value !== control.fields.content.val() ) {
 					control.fields.content.val( value ).trigger( 'change' );
 				}
 			});
 
 			// Make sure the editor gets updated if the content was updated on the server (sanitization) but not updated in the editor since it was focused.
-			control.editor.on( 'blur', function() {
+			control.editor.codemirror.on( 'blur', function() {
 				if ( control.contentUpdateBypassed ) {
 					control.syncContainer.find( '.sync-input.content' ).trigger( 'change' );
 				}

--- a/wp-admin/js/widgets/custom-html-widgets.js
+++ b/wp-admin/js/widgets/custom-html-widgets.js
@@ -60,7 +60,6 @@ wp.customHtmlWidgets = ( function( $ ) {
 
 			control.errorNoticeContainer = control.$el.find( '.code-editor-error-container' );
 			control.currentErrorAnnotations = [];
-			control.previousErrorCount = 0;
 			control.saveButton = control.syncContainer.add( control.syncContainer.parent().find( '.widget-control-actions' ) ).find( '.widget-control-save, #savewidget' );
 			control.saveButton.addClass( 'custom-html-widget-save-button' ); // To facilitate style targeting.
 
@@ -116,34 +115,28 @@ wp.customHtmlWidgets = ( function( $ ) {
 		/**
 		 * Show linting error notice.
 		 *
+		 * @param {Array} errorAnnotations - Error annotations.
 		 * @returns {void}
 		 */
-		updateErrorNotice: function() {
+		updateErrorNotice: function( errorAnnotations ) {
 			var control = this, errorNotice, message, customizeSetting;
 
-			if ( control.previousErrorCount === control.currentErrorAnnotations.length ) {
-				return;
-			}
-			control.previousErrorCount = control.currentErrorAnnotations.length;
-
-			control.saveButton.prop( 'disabled', 0 !== control.currentErrorAnnotations.length );
-
-			if ( 1 === control.currentErrorAnnotations.length ) {
+			if ( 1 === errorAnnotations.length ) {
 				message = component.l10n.errorNotice.singular.replace( '%d', '1' );
 			} else {
-				message = component.l10n.errorNotice.plural.replace( '%d', String( control.currentErrorAnnotations.length ) );
+				message = component.l10n.errorNotice.plural.replace( '%d', String( errorAnnotations.length ) );
 			}
 
 			if ( wp.customize && wp.customize.has( control.customizeSettingId ) ) {
 				customizeSetting = wp.customize( control.customizeSettingId );
 				customizeSetting.notifications.remove( 'htmllint_error' );
-				if ( 0 !== control.currentErrorAnnotations.length ) {
+				if ( 0 !== errorAnnotations.length ) {
 					customizeSetting.notifications.add( 'htmllint_error', new wp.customize.Notification( 'htmllint_error', {
 						message: message,
 						type: 'error'
 					} ) );
 				}
-			} else if ( 0 !== control.currentErrorAnnotations.length ) {
+			} else if ( 0 !== errorAnnotations.length ) {
 				errorNotice = $( '<div class="inline notice notice-error notice-alt"></div>' );
 				errorNotice.append( $( '<p></p>', {
 					text: message
@@ -170,37 +163,47 @@ wp.customHtmlWidgets = ( function( $ ) {
 			}
 
 			settings = _.extend( {}, component.codeEditorSettings, {
-				handleTabPrev: function() {
+
+				/**
+				 * Handle tabbing to the field before the editor.
+				 *
+				 * @returns {void}
+				 */
+				handleTabPrev: function handleTabPrev() {
 					control.fields.title.focus();
 				},
-				handleTabNext: function() {
+
+				/**
+				 * Handle tabbing to the field after the editor.
+				 *
+				 * @returns {void}
+				 */
+				handleTabNext: function handleTabNext() {
 					var tabbables = control.syncContainer.add( control.syncContainer.parent().find( '.widget-position, .widget-control-actions' ) ).find( ':tabbable' );
 					tabbables.first().focus();
+				},
+
+				/**
+				 * Disable save button and store linting errors for use in updateFields.
+				 *
+				 * @param {Array} errorAnnotations - Error notifications.
+				 * @returns {void}
+				 */
+				onChangeLintingErrors: function onChangeLintingErrors( errorAnnotations ) {
+					control.currentErrorAnnotations = errorAnnotations;
+				},
+
+				/**
+				 * Update error notice.
+				 *
+				 * @param {Array} errorAnnotations - Error annotations.
+				 * @returns {void}
+				 */
+				onUpdateErrorNotice: function onUpdateErrorNotice( errorAnnotations ) {
+					control.saveButton.prop( 'disabled', 0 !== errorAnnotations.length );
+					control.updateErrorNotice( errorAnnotations );
 				}
 			});
-
-			if ( settings.codemirror.lint ) {
-				if ( true === settings.codemirror.lint ) {
-					settings.codemirror.lint = {};
-				}
-				settings.codemirror.lint = _.extend( {}, settings.codemirror.lint, {
-					onUpdateLinting: function( annotations, annotationsSorted, editor ) {
-						control.currentErrorAnnotations = _.filter( annotations, function( annotation ) {
-							return 'error' === annotation.severity;
-						} );
-
-						/*
-						 * Update notifications when the editor is not focused to prevent error message
-						 * from overwhelming the user during input, unless there are no annotations
-						 * or there are previous notifications already being displayed, and in that
-						 * case update immediately so they can know that they fixed the errors.
-						 */
-						if ( ! editor.state.focused || 0 === control.currentErrorAnnotations.length || control.previousErrorCount > 0 ) {
-							control.updateErrorNotice();
-						}
-					}
-				});
-			}
 
 			control.editor = wp.codeEditor.initialize( control.fields.content, settings );
 			control.fields.content.on( 'change', function() {
@@ -214,16 +217,6 @@ wp.customHtmlWidgets = ( function( $ ) {
 					control.fields.content.val( value ).trigger( 'change' );
 				}
 			});
-
-			// Show the error notice when the user leaves the editor.
-			if ( settings.codemirror.lint ) {
-				control.editor.on( 'blur', function() {
-					control.updateErrorNotice();
-				});
-				$( control.editor.display.wrapper ).on( 'mouseout', function() {
-					control.updateErrorNotice();
-				});
-			}
 
 			// Make sure the editor gets updated if the content was updated on the server (sanitization) but not updated in the editor since it was focused.
 			control.editor.on( 'blur', function() {

--- a/wp-includes/general-template-addendum.php
+++ b/wp-includes/general-template-addendum.php
@@ -36,7 +36,6 @@ function wp_enqueue_code_editor( $args ) {
 			'inputStyle' => 'contenteditable',
 			'lineNumbers' => true,
 			'lineWrapping' => true,
-			'showTrailingSpace' => true,
 			'styleActiveLine' => true,
 			'continueComments' => true,
 			'extraKeys' => array(
@@ -225,7 +224,6 @@ function wp_enqueue_code_editor( $args ) {
 		$settings['codemirror'] = array_merge( $settings['codemirror'], array(
 			'mode' => 'gfm',
 			'highlightFormatting' => true,
-			'showTrailingSpace' => false, // GitHub-flavored markdown uses trailing spaces as a feature.
 		) );
 	} elseif ( 'application/javascript' === $type || 'text/javascript' === $type ) {
 		$settings['codemirror'] = array_merge( $settings['codemirror'], array(

--- a/wp-includes/general-template-addendum.php
+++ b/wp-includes/general-template-addendum.php
@@ -48,13 +48,12 @@ function wp_enqueue_code_editor( $args ) {
 			'direction' => 'ltr', // Code is shown in LTR even in RTL languages.
 		),
 		'csslint' => array(
-			'errors' => 2, // Parsing errors.
-			'box-model' => 1,
-			'display-property-grouping' => 1,
-			'duplicate-properties' => 1,
-			'empty-rules' => 1,
-			'known-properties' => 1,
-			'outline-none' => 1,
+			'errors' => true, // Parsing errors.
+			'box-model' => true,
+			'display-property-grouping' => true,
+			'duplicate-properties' => true,
+			'known-properties' => true,
+			'outline-none' => true,
 		),
 		'jshint' => array(
 			// The following are copied from <https://github.com/WordPress/wordpress-develop/blob/4.8.1/.jshintrc>.


### PR DESCRIPTION
* Only show “can't save” error notifications when focus is removed from editor so that error notices don't distract when typing.
* Remove `empty-rules` CSSLint rule and error indicator for trailing whitespace.
* Prevent hitting Esc from collapsing the widget control.
* Ensure CodeMirror editor for Additional CSS has bidirectional syncing.
* Refactor code to reduce duplication and improve API.

Fixes #13.