### PR TITLE
Improve disabling of save button for Custom HTML widget

### DIFF
--- a/wp-admin/css/widgets-addendum.css
+++ b/wp-admin/css/widgets-addendum.css
@@ -10,6 +10,6 @@
 ul.CodeMirror-hints {
 	z-index: 101; /* Due to z-index 100 set on .widget.open */
 }
-.widget-control-actions .custom-html-widget-save-button.button[disabled] {
+.widget-control-actions .custom-html-widget-save-button.button.validation-blocked {
 	cursor: not-allowed;
 }

--- a/wp-admin/js/widgets/custom-html-widgets.js
+++ b/wp-admin/js/widgets/custom-html-widgets.js
@@ -119,19 +119,23 @@ wp.customHtmlWidgets = ( function( $ ) {
 		 * @returns {void}
 		 */
 		updateErrorNotice: function( errorAnnotations ) {
-			var control = this, errorNotice, message, customizeSetting;
+			var control = this, errorNotice, message = '', customizeSetting;
 
 			if ( 1 === errorAnnotations.length ) {
 				message = component.l10n.errorNotice.singular.replace( '%d', '1' );
-			} else {
+			} else if ( errorAnnotations.length > 1 ) {
 				message = component.l10n.errorNotice.plural.replace( '%d', String( errorAnnotations.length ) );
+			}
+
+			if ( control.fields.content[0].setCustomValidity ) {
+				control.fields.content[0].setCustomValidity( message );
 			}
 
 			if ( wp.customize && wp.customize.has( control.customizeSettingId ) ) {
 				customizeSetting = wp.customize( control.customizeSettingId );
-				customizeSetting.notifications.remove( 'htmllint_error' );
+				customizeSetting.notifications.remove( 'htmlhint_error' );
 				if ( 0 !== errorAnnotations.length ) {
-					customizeSetting.notifications.add( 'htmllint_error', new wp.customize.Notification( 'htmllint_error', {
+					customizeSetting.notifications.add( 'htmlhint_error', new wp.customize.Notification( 'htmlhint_error', {
 						message: message,
 						type: 'error'
 					} ) );
@@ -200,7 +204,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 				 * @returns {void}
 				 */
 				onUpdateErrorNotice: function onUpdateErrorNotice( errorAnnotations ) {
-					control.saveButton.prop( 'disabled', 0 !== errorAnnotations.length );
+					control.saveButton.toggleClass( 'validation-blocked', errorAnnotations.length );
 					control.updateErrorNotice( errorAnnotations );
 				}
 			});


### PR DESCRIPTION
Fixes issue with core patch that also tries to disable the button, and they conflict.

See:
* https://github.com/xwp/wordpress-develop/pull/250
* https://core.trac.wordpress.org/ticket/41610